### PR TITLE
update setup to clean installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,25 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
-    name="brainsss",
-    version="0.0.1",
-    long_description=__doc__,
+    name='brainsss',
+    version='0.0.1',
+    long_description="""
+    This package performs preprocessing and analysis of 
+    volumetric neural data on sherlock. At its core, brainsss is a wrapper to 
+    interface with Slurm via python. It can handle complex submission of batches of 
+    jobs with job dependencies and makes it easy to pass variables between jobs. 
+    It also has full logging of job progress, output, and errors.
+    """,
     packages=['brainsss'],
     include_package_data=True,
-    install_requires=[],
-    zip_safe=False
+    install_requires=[
+        'pyfiglet',
+        'psutil',
+        'lxml',
+        'openpyxl',
+        'nibabel',
+        'numpy',
+        'pandas',
+        'pytest'
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ setup(
         'nibabel',
         'numpy',
         'pandas',
-        'pytest'
+        'pytest',
+        'scipy',
+        'h5py'
     ],
 )

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,11 @@
+# check whether the necessary modules are installed
+# any missing modules should be added to install_requires in setup.py
+
+import sys
+
+
+def test_imports():
+    sys.path.append('../brainsss')
+    import fictrac
+    import utils
+    import visual

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,11 +1,17 @@
 # check whether the necessary modules are installed
 # any missing modules should be added to install_requires in setup.py
+# this must be run from the root directory of the project or the tests directory
 
 import sys
-
+import os
 
 def test_imports():
-    sys.path.append('../brainsss')
+    if os.path.exists('brainsss'):
+        sys.path.append('brainsss')
+    elif os.path.exists('../brainsss'):
+        sys.path.append('../brainsss')
+    else:
+        raise Exception('brainsss directory not found')
     import fictrac
     import utils
     import visual


### PR DESCRIPTION
### Problem:
setup.py did not include install requirements

### Solution:
Modified setup to work from a clean install (python 3.8 under conda)
- setup.py modified to include the long description from readme, and to install all required packages
- created tests/test_imports.py to test that all necessary modules are installed

### Notes: 

Test must be run from the main project directory or the tests directory

To check:

```
conda create -y -n brainsss_test python=3.8
conda activate brainss_test
pytest
```